### PR TITLE
Fix (very) minor typo in docker installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install the system dependencies below to build this project by following the ins
 Prepare your embassyOS build environment. In this example we are using Ubuntu 20.04.
 1. Install docker
 ```
-curl -fsSL https://get.docker.com -o | bash
+curl -fsSL https://get.docker.com | bash
 sudo usermod -aG docker "$USER"
 exec sudo su -l $USER
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install the system dependencies below to build this project by following the ins
 Prepare your embassyOS build environment. In this example we are using Ubuntu 20.04.
 1. Install docker
 ```
-curl -fsSL https://get.docker.com -o- | bash
+curl -fsSL https://get.docker.com -o | bash
 sudo usermod -aG docker "$USER"
 exec sudo su -l $USER
 ```


### PR DESCRIPTION
The trailing slash in the curl params has no effect, but it threw me off

This PR goes hand in hand with https://github.com/Start9Labs/documentation/pull/322